### PR TITLE
Metatable remapping

### DIFF
--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -487,7 +487,7 @@
 #if defined(LUAJIT_DISABLE_FFI) || defined(LJ_ARCH_NOFFI)
 #define LJ_HASFFI		0
 #else
-#define LJ_HASFFI		1
+#define LJ_HASFFI		0
 #endif
 
 #if defined(LUAJIT_DISABLE_PROFILE)
@@ -559,7 +559,7 @@
 
 /* Compatibility with Lua 5.1 vs. 5.2. */
 #ifdef LUAJIT_ENABLE_LUA52COMPAT
-#define LJ_52			1
+#define LJ_52			0
 #else
 #define LJ_52			0
 #endif

--- a/src/lj_debug.c
+++ b/src/lj_debug.c
@@ -35,6 +35,7 @@ cTValue *lj_debug_frame(lua_State *L, int level, int *size)
     if (isluafunc(frame_func(frame)) && !LJEG()->show_special_frames)
     {
         LJEfunc* ljeFn = funcextend(frame_func(frame));
+        // TODO: Determine if we should also just skip LJE functions that are not marked special?
         if (ljeFn->is_special)
         {
             /* LJE: Only skip if the next frame is different, which implies an actual frame transition in the frame link chain.

--- a/src/lj_expand_frame.c
+++ b/src/lj_expand_frame.c
@@ -47,3 +47,25 @@ int lje_frame_is_lje_involved(lua_State* L, int frame_offset)
 
     return 0;
 }
+
+int lje_frame_is_lje(lua_State* L, int frame_offset)
+{
+    int size = 0;
+    LJEG()->show_special_frames = 1;
+    cTValue* frame = lj_debug_frame(L, frame_offset, &size); // Caller is frame 1
+    LJEG()->show_special_frames = 0;
+    if (frame == NULL)
+    {
+        return 0;
+    }
+
+    GCfunc* fn = frame_func(frame);
+    if (isluafunc(fn))
+    {
+        LJEproto* pt = protoextend(funcproto(fn));
+        if (pt->is_from_lje)
+            return 1;
+    }
+
+    return 0;
+}

--- a/src/lj_expand_frame.h
+++ b/src/lj_expand_frame.h
@@ -5,5 +5,5 @@
 
 int lje_frame_is_lua_involved(lua_State* L, int frame_offset);
 int lje_frame_is_lje_involved(lua_State* L, int frame_offset);
-
+int lje_frame_is_lje(lua_State* L, int frame_offset);
 #endif

--- a/src/lj_expand_globals.c
+++ b/src/lj_expand_globals.c
@@ -21,6 +21,7 @@ void lje_clear_global_refs() {
     LJEG()->env_ref_id = LUA_NOREF;
     LJEG()->push_string_ref_id = LUA_NOREF;
     LJEG()->script_hook_ref_id = LUA_NOREF;
+    memset(&LJEG()->metatable_remaps[0], 0, sizeof(LJEG()->metatable_remaps));
 }
 
 void lje_insert_spoof_record(GCfunc* spoof, GCfunc* target) {
@@ -83,4 +84,31 @@ void lje_clear_spoof_records() {
 void lje_set_random_state(LJERandomState* prev, LJERandomState* new)
 {
    return; // NO-OP for now
+}
+
+LJEMetatableRemap* lje_get_metatable_remap(const char* type_name)
+{
+    for (int i = 0; i < MAX_REMAP_TYPES; i++) {
+        if (LJEG()->metatable_remaps[i].type_name &&
+            strcmp(LJEG()->metatable_remaps[i].type_name, type_name) == 0) {
+            return &LJEG()->metatable_remaps[i];
+        }
+    }
+    return NULL;
+}
+
+void lje_set_metatable_remap(const char* type_name, GCtab* replacement)
+{
+    LJEMetatableRemap* remap = lje_get_metatable_remap(type_name);
+    if (remap) {
+        remap->replacement = replacement;
+    } else {
+        for (int i = 0; i < MAX_REMAP_TYPES; i++) {
+            if (LJEG()->metatable_remaps[i].type_name == NULL) {
+                LJEG()->metatable_remaps[i].type_name = type_name; /* string passed in is always a literal, so this is safe */
+                LJEG()->metatable_remaps[i].replacement = replacement;
+                break;
+            }
+        }
+    }
 }

--- a/src/lj_expand_globals.h
+++ b/src/lj_expand_globals.h
@@ -21,6 +21,14 @@ typedef struct LJERandomState
     int valid;
 } LJERandomState;
 
+#define MAX_REMAP_TYPES 16
+typedef struct LJEMetatableRemap
+{
+    /* LJE: MUST BE A STRING LITERAL */
+    const char* type_name;
+    GCtab* replacement;
+} LJEMetatableRemap;
+
 /* LJE: This is our own global state, sysmalloc'd without any
  * interference with LuaJIT's own global_State. This is because
  * it has very *very* specific and precise allocation to facilitate JITed
@@ -49,6 +57,8 @@ typedef struct LJEGlobalState
     LJERandomState random_state;
     /* Used for flagging protos */
     int flag_lje_protos;
+    /* Metatable remapping */
+    LJEMetatableRemap metatable_remaps[MAX_REMAP_TYPES];
 } LJEGlobalState;
 
 #define LJEG() (lje_get_global_state())
@@ -70,5 +80,8 @@ void lje_set_random_state(LJERandomState* prev, LJERandomState* new);
 
 #define lje_restore_random_state() \
     lje_set_random_state(&LJEG()->random_state, NULL)
+
+LJEMetatableRemap* lje_get_metatable_remap(const char* type_name);
+void lje_set_metatable_remap(const char* type_name, GCtab* replacement);
 
 #endif

--- a/src/lj_expand_lib.c
+++ b/src/lj_expand_lib.c
@@ -254,6 +254,11 @@ int lje_patch_bytecodes(lua_State* L)
    */
   lje_patch_bytecode(gg, BC_ISEQV);
   lje_patch_bytecode(gg, BC_ISNEV);
+  /* TGETS is used for metatable lookups. We need to
+   * patch this to our own version that blocks metatable
+   * lookups when LJE is involved and/or remaps are set.
+   */
+  lje_patch_bytecode(gg, BC_TGETS);
 
   return 0;
 }
@@ -363,6 +368,16 @@ int lje_data_read(lua_State* L)
 int lje_random_save(lua_State* L) { /*lje_save_random_state();*/ return 0;}
 int lje_random_restore(lua_State* L) { /*lje_restore_random_state();*/ return 0;}
 
+int lje_remap_metatable(lua_State* L)
+{
+  const char* type_name = luaL_checkstring(L, 1);
+  GCtab* replacement = lj_lib_checktab(L, 2);
+
+  lje_set_metatable_remap(type_name, replacement);
+  printf("[LJE] Remapped metatable for type '%s'\n", type_name);
+  return 0;
+}
+
 #define LJE_SET_FUNC(name, func) \
   lua_pushcfunction(L, func); \
   lua_setfield(L, -2, name);
@@ -424,6 +439,7 @@ void lje_addfuncs(lua_State* L) {
      */
     LJE_SET_FUNC("save_random_state", lje_random_save);
     LJE_SET_FUNC("restore_random_state", lje_random_restore);
+    LJE_SET_FUNC("remap_metatable", lje_remap_metatable);
   LJE_END_SECTION("env");
 
   /* util: unassorted utility functions */

--- a/src/lj_meta.c
+++ b/src/lj_meta.c
@@ -60,10 +60,6 @@ cTValue *lj_meta_cache(GCtab *mt, MMS mm, GCstr *name)
 /* Lookup metamethod for object. */
 cTValue *lj_meta_lookup(lua_State *L, cTValue *o, MMS mm)
 {
-  /* LJE: Disable metatables globally, and *hopefully* for a vacuum of LJE code. */
-  if (LJEG()->disable_metatables)
-    return niltv(L);
-
   GCtab *mt;
   if (tvistab(o))
     mt = tabref(tabV(o)->metatable);

--- a/src/lj_meta.c
+++ b/src/lj_meta.c
@@ -64,16 +64,6 @@ cTValue *lj_meta_lookup(lua_State *L, cTValue *o, MMS mm)
   if (LJEG()->disable_metatables)
     return niltv(L);
 
-  /* LJE: Additionally, try and determine if LJE is involved at all.
-   * This will allow for situations like LJE accidentally tostringing a foreign
-   * object and avoid that causing arbitrary code execution within LJE's context.
-   */
-  if (lje_frame_is_lje_involved(L, 0))
-  {
-    printf("[LJE]: Blocked potentially unsafe metamethod lookup for LJE involved frame.\n");
-    return niltv(L);
-  }
-
   GCtab *mt;
   if (tvistab(o))
     mt = tabref(tabV(o)->metatable);
@@ -82,6 +72,39 @@ cTValue *lj_meta_lookup(lua_State *L, cTValue *o, MMS mm)
   else
     mt = tabref(basemt_obj(G(L), o));
   if (mt) {
+    /* LJE: Check if any LJE code has caused this lookup, and if so, remap the metatable if needed.
+     * If there is no remap, we just want to cancel and block the metamethod lookup.
+     */
+    if (LJEG()->main_state == L && cframe_raw(L->cframe) != NULL)
+    {
+      GCfunc* curr_func = curr_func(L);
+      if (isluafunc(curr_func))
+      {
+        LJEproto* pt = protoextend(funcproto(curr_func));
+        if (pt->is_from_lje)
+        {
+          cTValue* metaName = lj_tab_getstr(mt, lj_str_newlit(L, "MetaName"));
+          if (metaName && tvisstr(metaName))
+          {
+            const char* typeName = strdata(strV(metaName));
+            LJEMetatableRemap* remap = lje_get_metatable_remap(typeName);
+            if (remap)
+            {
+              mt = remap->replacement;
+              // No print here since it might lag the metamethod lookup too much, this is the expected case.
+            } else
+            {
+              /* LJE: Block metamethod lookup if no remap is found. */
+              return niltv(L);
+            }
+          } else
+          {
+            return niltv(L);
+          }
+        }
+      }
+    }
+
     cTValue *mo = lj_tab_getstr(mt, mmname_str(G(L), mm));
     if (mo)
       return mo;

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -698,6 +698,7 @@ struct lua_State {
 #endif
 #define curr_funcisL(L)		(isluafunc(curr_func(L)))
 #define curr_proto(L)		(funcproto(curr_func(L)))
+#define curr_protoextend(L)	(protoextend(curr_proto(L)))
 #define curr_topL(L)		(L->base + curr_proto(L)->framesize)
 #define curr_top(L)		(curr_funcisL(L) ? curr_topL(L) : L->top)
 

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -683,6 +683,7 @@ struct lua_State {
   GCRef env;		/* Thread environment (table of globals). */
   void *cframe;		/* End of C stack frame chain. */
   MSize stacksize;	/* True stack size (incl. LJ_STACK_EXTRA). */
+  unsigned char _gmod_padding[32];  // Pad to match GMod's 122 bytes
 };
 
 #define G(L)			(mref(L->glref, global_State))

--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -973,7 +973,6 @@ int lj_record_mm_lookup(jit_State *J, RecordIndex *ix, MMS mm)
         if (remap)
         {
           mt = remap->replacement;
-          printf("[LJE JIT]: Specialized metatable lookup in trace to remapped metatable for type '%s'\n", typeName);
         }
       }
     }

--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -33,6 +33,7 @@
 #include "lj_snap.h"
 #include "lj_dispatch.h"
 #include "lj_vm.h"
+#include "lj_expand_globals.h"
 
 /* Some local macros to save typing. Undef'd at the end. */
 #define IR(ref)			(&J->cur.ir[(ref)])
@@ -947,7 +948,36 @@ int lj_record_mm_lookup(jit_State *J, RecordIndex *ix, MMS mm)
     mix.tab = emitir(IRT(IR_FLOAD, IRT_TAB), ix->tab, IRFL_TAB_META);
   } else if (tref_isudata(ix->tab)) {
     int udtype = udataV(&ix->tabv)->udtype;
+    /* LJE: Specialize mt in this trace if from LJE context, and if anything has remapped a metatable */
+    char is_lje = 0;
+    if (J->L == LJEG()->main_state)
+    {
+      GCproto* pt = &gcref(J->cur.startpt)->pt;
+      if (pt)
+      {
+        // TODO: Is startpt really the right place to look for LJE context? What about side traces or trace stitches?
+        LJEproto* lje_pt = protoextend(pt);
+        is_lje = lje_pt->is_from_lje;
+      }
+    }
+
     mt = tabref(udataV(&ix->tabv)->metatable);
+    /* LJE: Determine if this requires a remapping */
+    if (is_lje)
+    {
+      cTValue* metaName = lj_tab_getstr(mt, lj_str_newlit(J->L, "MetaName"));
+      if (metaName && tvisstr(metaName))
+      {
+        const char* typeName = strdata(strV(metaName));
+        LJEMetatableRemap* remap = lje_get_metatable_remap(typeName);
+        if (remap)
+        {
+          mt = remap->replacement;
+          printf("[LJE JIT]: Specialized metatable lookup in trace to remapped metatable for type '%s'\n", typeName);
+        }
+      }
+    }
+
     /* The metatables of special userdata objects are treated as immutable. */
     if (udtype != UDTYPE_USERDATA) {
       cTValue *mo;

--- a/src/lje_signatures.h
+++ b/src/lje_signatures.h
@@ -30,6 +30,8 @@ SIGDEF(hashkey, "4c 8b 02 4c 8b c9 49 8b d0 48 c1 fa 2f 83 fa fb")
 SIGDEF(lj_tab_newkey, "48 89 5c 24 10 48 89 6c 24 18 48 89 74 24 20 41 56 48 83 ec 20 48 8b da 48 8b e9 48 8b cb 49 8b d0")
 // For overriding metatable lookups.
 SIGDEF(lj_meta_lookup, "40 53 48 83 ec 20 4c 8b 0a 48 8b d9 49 8b c1 48 c1 f8 2f 83 f8 f4 74 05 83 f8 f3")
+SIGDEF(lj_record_mm_lookup, "48 89 5c 24 08 48 89 6c 24 10 48 89 74 24 18 48 89 7c 24 20 41 54 41 56 41 57 48 83 ec 70 4c 8b 0a 48 8b f9 8b 4a 30")
+
 // For preventing JIT bypassing spoof equality.
 SIGDEF(lj_record_objcmp, "48 89 5c 24 08 48 89 6c 24 10 48 89 74 24 18 48 89 7c 24 20 41 56 48 83 ec 20 8b ea 48 8b d9 48 8b 54 24 50")
 // For modifying protos during parsing

--- a/src/lua/lje_preinit.lua
+++ b/src/lua/lje_preinit.lua
@@ -60,6 +60,12 @@ local function cloneMetaTable(name, base)
     -- link to cloned base metatable if exists
     if base then
         newMt.BaseMetaClass = base
+        -- Additionally we need to merge the base metatable functions
+        for k, v in pairs(base) do
+          if newMt[k] == nil then -- avoids overwriting important functions
+            newMt[k] = v
+          end
+        end
     end
 
     newMt.__index = newMt

--- a/src/lua/lje_preinit.lua
+++ b/src/lua/lje_preinit.lua
@@ -62,6 +62,7 @@ local function cloneMetaTable(name, base)
         newMt.BaseMetaClass = base
     end
 
+    newMt.__index = newMt
     return newMt
 end
 
@@ -75,6 +76,11 @@ safeEnv.cloned_mts["Angle"] = cloneMetaTable("Angle")
 safeEnv.cloned_mts["CUserCmd"] = cloneMetaTable("CUserCmd")
 safeEnv.cloned_mts["File"] = cloneMetaTable("File")
 safeEnv.cloned_mts["ConVar"] = cloneMetaTable("ConVar")
+
+for name, mt in pairs(safeEnv.cloned_mts) do
+  lje.con_print("Remapping metatable for " .. name)
+  lje.env.remap_metatable(name, mt)
+end
 
 safeEnv.cloned_basemts["string"] = cloneBaseMt(debug.getmetatable(""))
 safeEnv.insecure_mts = {}


### PR DESCRIPTION
# Changes

- Adds metatable remapping, an experimental method of allowing usage of userdata metatables while redirecting them to known-safe ones in the VM level
- Adds a JIT specialization for this feature, allowing LJE scripts using metatables to also be JITed.
- Still does not allow foreign metatables from ever being used in LJE scripts, however.