### PR TITLE
Error propagation control

### DIFF
--- a/src/lj_err.c
+++ b/src/lj_err.c
@@ -602,13 +602,87 @@ static ptrdiff_t finderrfunc(lua_State *L)
   return 0;
 }
 
+static void lje_debug_lua_frame_func(cTValue *frame)
+{
+  GCfunc* func = frame_func(frame);
+  if (isluafunc(func))
+    printf("[LJE] Lua function from: %s\n", proto_chunkname(funcproto(func)) ? proto_chunknamestr(funcproto(func)) : "unknown");
+  else
+    printf("[LJE] C function: %p\n", func);
+}
+
+static void lje_debug_frame(lua_State *L, cTValue *frame)
+{
+  switch (frame_typep(frame))
+  {
+  case FRAME_LUA:
+  case FRAME_LUAP:
+    printf("[LJE] Lua frame: %p\n", frame_func(frame));
+    printf("[LJE] Lua frame func type: %s\n", isluafunc(frame_func(frame)) ? "Lua" : "C");
+    lje_debug_lua_frame_func(frame);
+    const char* fname = "?";
+    const char *ftype = lj_debug_funcname(L, frame, &fname);
+    if (ftype)
+      printf("[LJE] Function name: %s (type: %s)\n", fname, ftype);
+    else
+      printf("[LJE] Function name: %s\n", fname);
+
+    break;
+  case FRAME_C:
+    printf("[LJE] C frame: %p\n", frame_func(frame));
+    break;
+  case FRAME_VARG:
+    printf("[LJE] Vararg frame: %p\n", frame_func(frame));
+    const char* fname_varg = "?";
+    const char *ftype_varg = lj_debug_funcname(L, frame, &fname_varg);
+    if (ftype_varg)
+      printf("[LJE] Function name: %s (type: %s)\n", fname_varg, ftype_varg);
+    else
+      printf("[LJE] Function name: %s\n", fname_varg);
+    break;
+  case FRAME_CONT:
+    printf("[LJE] Continuation frame: %p\n", frame_func(frame));
+    break;
+  case FRAME_CP:
+    printf("[LJE] Protected C frame: %p\n", frame_func(frame));
+    const char* fname_cp = "?";
+    const char *ftype_cp = lj_debug_funcname(L, frame, &fname_cp);
+    if (ftype_cp)
+      printf("[LJE] Function name: %s (type: %s)\n", fname_cp, ftype_cp);
+    else
+      printf("[LJE] Function name: %s\n", fname_cp);
+
+    break;
+  case FRAME_PCALL:
+    printf("[LJE] pcall frame: %p\n", frame_func(frame));
+    printf("[LJE] pcall frame func type: %s\n", isluafunc(frame_func(frame)) ? "Lua" : "C");
+    lje_debug_lua_frame_func(frame);
+    break;
+  case FRAME_PCALLH:
+    printf("[LJE] pcall (in hook) frame: %p\n", frame_func(frame));
+    break;
+  default:
+    printf("[LJE] Unknown frame type: %d\n", frame_typep(frame));
+    break;
+  }
+}
+
 char lje_find_pcall(lua_State* L)
 {
   cTValue* frame, *bot = tvref(L->stack) + LJ_FR2;
+  printf("[LJE] Traversing...\n");
+  int index = 0;
+
   for (frame = L->base - 1; frame > bot;)
   {
+    index++;
     if (frame_typep(frame) == FRAME_PCALL || frame_typep(frame) == FRAME_PCALLH)
     {
+      printf("[LJE] Found pcall frame in callstack.\n");
+      /* LJE: Determine if this pcall frame is protecting LJE code. If so, we need to figure out who is handling it before allowing
+       * usual unwinding.
+       */
+
       GCfunc* protected_func = frame_func(frame);
       if (isljefunc(protected_func))
       {
@@ -620,23 +694,34 @@ char lje_find_pcall(lua_State* L)
           /* LJE: The handler frame is not trusted. This could usually be caused by some foreign code pcalling a LJE function.
            * We cannot allow the error to propagate to untrusted code, as that would lead to detection.
            */
+          printf("[LJE] Found untrusted pcall handler frame. Blocking error from propagating to it.\n");
           return 0;
         } else
         {
           /* LJE: The handler frame is trusted LJE code. We can allow the error to be handled here. and not need to block it. */
+          printf("[LJE] Found trusted LJE pcall handler frame. Allowing error to propagate to it.\n");
           return 1;
         }
       }
     }
 
+    GCfunc* func = frame_func(frame);
+    if (func && isluafunc(func))
+      printf("[LJE] %d. Frame: %s\n", index, proto_chunkname(funcproto(func)) ? proto_chunknamestr(funcproto(func)) : "unknown");
+    else
+      printf("[LJE] %d. Frame: C function %p\n", index, func);
+
     if (frame_islua(frame))
     {
+      printf("[LJE] Traversing Lua frame.\n");
       frame = frame_prevl(frame);
     } else
     {
+      printf("[LJE] Traversing non-Lua frame.\n");
       frame = frame_prevd(frame);
     }
   }
+  printf("[LJE] Finished traversing callstack.\n");
 
   return 0;
 }
@@ -676,6 +761,8 @@ LJ_NOINLINE void lj_err_run(lua_State *L)
        * inherit this broken stack.
        */
       L->top = L->base;
+      if (LJ_FR2) setnilV(L->top++);
+
       lj_err_throw(L, LUA_OK);
     }
   }

--- a/src/lj_err.c
+++ b/src/lj_err.c
@@ -602,6 +602,45 @@ static ptrdiff_t finderrfunc(lua_State *L)
   return 0;
 }
 
+char lje_find_pcall(lua_State* L)
+{
+  cTValue* frame, *bot = tvref(L->stack) + LJ_FR2;
+  for (frame = L->base - 1; frame > bot;)
+  {
+    if (frame_typep(frame) == FRAME_PCALL || frame_typep(frame) == FRAME_PCALLH)
+    {
+      GCfunc* protected_func = frame_func(frame);
+      if (isljefunc(protected_func))
+      {
+        /* LJE: This is protected LJE code. We need to find the handler for it, which is located after the pcall's C frame. */
+        cTValue* pcall_cframe = frame_prev(frame);
+        cTValue* handler_frame = frame_prev(pcall_cframe);
+        if (!isljefunc(frame_func(handler_frame)))
+        {
+          /* LJE: The handler frame is not trusted. This could usually be caused by some foreign code pcalling a LJE function.
+           * We cannot allow the error to propagate to untrusted code, as that would lead to detection.
+           */
+          return 0;
+        } else
+        {
+          /* LJE: The handler frame is trusted LJE code. We can allow the error to be handled here. and not need to block it. */
+          return 1;
+        }
+      }
+    }
+
+    if (frame_islua(frame))
+    {
+      frame = frame_prevl(frame);
+    } else
+    {
+      frame = frame_prevd(frame);
+    }
+  }
+
+  return 0;
+}
+
 /* Runtime error. */
 LJ_NOINLINE void lj_err_run(lua_State *L)
 {
@@ -609,31 +648,36 @@ LJ_NOINLINE void lj_err_run(lua_State *L)
   /* LJE: Block any errors surfacing from LJE code. */
   if (lje_frame_is_lje_involved(L, 0))
   {
-    printf("[LJE] Detected runtime error from LJE code. Blocking error from reaching GMod.\n");
-    cTValue* potential_error_msg = L->top - 1;
-    if (tvisstr(potential_error_msg))
-      printf("[LJE] Error message: %s\n", strdata(strV(potential_error_msg)));
-
-    LJEG()->show_special_frames = 1;
-    luaL_traceback(L, L, "[LJE] stack traceback:", 1);
-    LJEG()->show_special_frames = 0;
-    TValue* traceback = L->top - 1;
-    if (tvisstr(traceback))
-      printf("%s\n", strdata(strV(traceback)));
-    L->top--;
-
-    /* Before we throw, we need to manually fix the stack since we arent causing an actual error to be thrown */
-    if (ef)
+    /* LJE: However, we need to ensure that there is no LJE pcall expecting to handle it. */
+    char lje_pcall_found = lje_find_pcall(L);
+    if (!lje_pcall_found)
     {
+      printf("[LJE] Detected runtime error from LJE code. Blocking error from reaching GMod.\n");
+      cTValue* potential_error_msg = L->top - 1;
+      if (tvisstr(potential_error_msg))
+        printf("[LJE] Error message: %s\n", strdata(strV(potential_error_msg)));
+
+      LJEG()->show_special_frames = 1;
+      luaL_traceback(L, L, "[LJE] stack traceback:", 1);
+      LJEG()->show_special_frames = 0;
+      TValue* traceback = L->top - 1;
+      if (tvisstr(traceback))
+        printf("%s\n", strdata(strV(traceback)));
+      L->top--;
+
       lj_trace_abort(G(L));
 
       /* Clean the callstack */
       L->base = tvref(L->stack) + 1 + LJ_FR2;  // Reset to bottom of stack
       L->cframe = NULL;                        // Clear C frame chain
       unwindstack(L, L->base);                 // Close upvalues and clean stack
-    }
 
-    lj_err_throw(L, LUA_OK);
+      /* Before leaving, we also need to clear the stack too. Coroutines can sometimes
+       * inherit this broken stack.
+       */
+      L->top = L->base;
+      lj_err_throw(L, LUA_OK);
+    }
   }
 
   if (ef) {

--- a/src/lj_err.c
+++ b/src/lj_err.c
@@ -748,7 +748,6 @@ LJ_NOINLINE void lj_err_run(lua_State *L)
       TValue* traceback = L->top - 1;
       if (tvisstr(traceback))
         printf("%s\n", strdata(strV(traceback)));
-      L->top--;
 
       lj_trace_abort(G(L));
 
@@ -761,7 +760,12 @@ LJ_NOINLINE void lj_err_run(lua_State *L)
        * inherit this broken stack.
        */
       L->top = L->base;
-      if (LJ_FR2) setnilV(L->top++);
+      if (LJ_FR2) {
+        setnilV(L->top++);
+      }
+
+      L->top++;
+      setstrV(L, L->top - 1, lj_err_str(L, LJ_ERR_BADARG)); /* Random placeholder so that GMod-specific C Lua usage wont over-pop the stack */
 
       lj_err_throw(L, LUA_OK);
     }

--- a/src/lj_err.c
+++ b/src/lj_err.c
@@ -602,83 +602,13 @@ static ptrdiff_t finderrfunc(lua_State *L)
   return 0;
 }
 
-static void lje_debug_lua_frame_func(cTValue *frame)
-{
-  GCfunc* func = frame_func(frame);
-  if (isluafunc(func))
-    printf("[LJE] Lua function from: %s\n", proto_chunkname(funcproto(func)) ? proto_chunknamestr(funcproto(func)) : "unknown");
-  else
-    printf("[LJE] C function: %p\n", func);
-}
-
-static void lje_debug_frame(lua_State *L, cTValue *frame)
-{
-  switch (frame_typep(frame))
-  {
-  case FRAME_LUA:
-  case FRAME_LUAP:
-    printf("[LJE] Lua frame: %p\n", frame_func(frame));
-    printf("[LJE] Lua frame func type: %s\n", isluafunc(frame_func(frame)) ? "Lua" : "C");
-    lje_debug_lua_frame_func(frame);
-    const char* fname = "?";
-    const char *ftype = lj_debug_funcname(L, frame, &fname);
-    if (ftype)
-      printf("[LJE] Function name: %s (type: %s)\n", fname, ftype);
-    else
-      printf("[LJE] Function name: %s\n", fname);
-
-    break;
-  case FRAME_C:
-    printf("[LJE] C frame: %p\n", frame_func(frame));
-    break;
-  case FRAME_VARG:
-    printf("[LJE] Vararg frame: %p\n", frame_func(frame));
-    const char* fname_varg = "?";
-    const char *ftype_varg = lj_debug_funcname(L, frame, &fname_varg);
-    if (ftype_varg)
-      printf("[LJE] Function name: %s (type: %s)\n", fname_varg, ftype_varg);
-    else
-      printf("[LJE] Function name: %s\n", fname_varg);
-    break;
-  case FRAME_CONT:
-    printf("[LJE] Continuation frame: %p\n", frame_func(frame));
-    break;
-  case FRAME_CP:
-    printf("[LJE] Protected C frame: %p\n", frame_func(frame));
-    const char* fname_cp = "?";
-    const char *ftype_cp = lj_debug_funcname(L, frame, &fname_cp);
-    if (ftype_cp)
-      printf("[LJE] Function name: %s (type: %s)\n", fname_cp, ftype_cp);
-    else
-      printf("[LJE] Function name: %s\n", fname_cp);
-
-    break;
-  case FRAME_PCALL:
-    printf("[LJE] pcall frame: %p\n", frame_func(frame));
-    printf("[LJE] pcall frame func type: %s\n", isluafunc(frame_func(frame)) ? "Lua" : "C");
-    lje_debug_lua_frame_func(frame);
-    break;
-  case FRAME_PCALLH:
-    printf("[LJE] pcall (in hook) frame: %p\n", frame_func(frame));
-    break;
-  default:
-    printf("[LJE] Unknown frame type: %d\n", frame_typep(frame));
-    break;
-  }
-}
-
 char lje_find_pcall(lua_State* L)
 {
   cTValue* frame, *bot = tvref(L->stack) + LJ_FR2;
-  printf("[LJE] Traversing...\n");
-  int index = 0;
-
   for (frame = L->base - 1; frame > bot;)
   {
-    index++;
     if (frame_typep(frame) == FRAME_PCALL || frame_typep(frame) == FRAME_PCALLH)
     {
-      printf("[LJE] Found pcall frame in callstack.\n");
       /* LJE: Determine if this pcall frame is protecting LJE code. If so, we need to figure out who is handling it before allowing
        * usual unwinding.
        */
@@ -694,34 +624,23 @@ char lje_find_pcall(lua_State* L)
           /* LJE: The handler frame is not trusted. This could usually be caused by some foreign code pcalling a LJE function.
            * We cannot allow the error to propagate to untrusted code, as that would lead to detection.
            */
-          printf("[LJE] Found untrusted pcall handler frame. Blocking error from propagating to it.\n");
           return 0;
         } else
         {
           /* LJE: The handler frame is trusted LJE code. We can allow the error to be handled here. and not need to block it. */
-          printf("[LJE] Found trusted LJE pcall handler frame. Allowing error to propagate to it.\n");
           return 1;
         }
       }
     }
 
-    GCfunc* func = frame_func(frame);
-    if (func && isluafunc(func))
-      printf("[LJE] %d. Frame: %s\n", index, proto_chunkname(funcproto(func)) ? proto_chunknamestr(funcproto(func)) : "unknown");
-    else
-      printf("[LJE] %d. Frame: C function %p\n", index, func);
-
     if (frame_islua(frame))
     {
-      printf("[LJE] Traversing Lua frame.\n");
       frame = frame_prevl(frame);
     } else
     {
-      printf("[LJE] Traversing non-Lua frame.\n");
       frame = frame_prevd(frame);
     }
   }
-  printf("[LJE] Finished traversing callstack.\n");
 
   return 0;
 }
@@ -737,13 +656,12 @@ LJ_NOINLINE void lj_err_run(lua_State *L)
     char lje_pcall_found = lje_find_pcall(L);
     if (!lje_pcall_found)
     {
-      printf("[LJE] Detected runtime error from LJE code. Blocking error from reaching GMod.\n");
       cTValue* potential_error_msg = L->top - 1;
       if (tvisstr(potential_error_msg))
-        printf("[LJE] Error message: %s\n", strdata(strV(potential_error_msg)));
+        printf("[LJE ERROR] %s\n", strdata(strV(potential_error_msg)));
 
       LJEG()->show_special_frames = 1;
-      luaL_traceback(L, L, "[LJE] stack traceback:", 1);
+      luaL_traceback(L, L, NULL, 1);
       LJEG()->show_special_frames = 0;
       TValue* traceback = L->top - 1;
       if (tvisstr(traceback))

--- a/src/lj_err.c
+++ b/src/lj_err.c
@@ -9,6 +9,8 @@
 #include "lj_obj.h"
 #include "lj_err.h"
 #include "lj_debug.h"
+#include "lj_expand_frame.h"
+#include "lj_expand_globals.h"
 #include "lj_str.h"
 #include "lj_func.h"
 #include "lj_state.h"
@@ -604,6 +606,36 @@ static ptrdiff_t finderrfunc(lua_State *L)
 LJ_NOINLINE void lj_err_run(lua_State *L)
 {
   ptrdiff_t ef = finderrfunc(L);
+  /* LJE: Block any errors surfacing from LJE code. */
+  if (lje_frame_is_lje_involved(L, 0))
+  {
+    printf("[LJE] Detected runtime error from LJE code. Blocking error from reaching GMod.\n");
+    cTValue* potential_error_msg = L->top - 1;
+    if (tvisstr(potential_error_msg))
+      printf("[LJE] Error message: %s\n", strdata(strV(potential_error_msg)));
+
+    LJEG()->show_special_frames = 1;
+    luaL_traceback(L, L, "[LJE] stack traceback:", 1);
+    LJEG()->show_special_frames = 0;
+    TValue* traceback = L->top - 1;
+    if (tvisstr(traceback))
+      printf("%s\n", strdata(strV(traceback)));
+    L->top--;
+
+    /* Before we throw, we need to manually fix the stack since we arent causing an actual error to be thrown */
+    if (ef)
+    {
+      lj_trace_abort(G(L));
+
+      /* Clean the callstack */
+      L->base = tvref(L->stack) + 1 + LJ_FR2;  // Reset to bottom of stack
+      L->cframe = NULL;                        // Clear C frame chain
+      unwindstack(L, L->base);                 // Close upvalues and clean stack
+    }
+
+    lj_err_throw(L, LUA_OK);
+  }
+
   if (ef) {
     TValue *errfunc = restorestack(L, ef);
     TValue *top = L->top;

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -468,9 +468,13 @@ typedef struct LJEproto
 
 #define FF_LUA		0
 #define FF_C		1
+#define protoextend(pt) \
+(LJEproto*)((char*)(pt) + (pt->sizept - sizeof(LJEproto)))
 #define isluafunc(fn)	((fn)->c.ffid == FF_LUA)
 #define iscfunc(fn)	((fn)->c.ffid == FF_C)
 #define isffunc(fn)	((fn)->c.ffid > FF_C)
+#define isljefunc(fn) \
+  (isluafunc(fn) && ((protoextend(funcproto(fn)))->is_from_lje))
 #define funcproto(fn) \
   check_exp(isluafunc(fn), (GCproto *)(mref((fn)->l.pc, char)-sizeof(GCproto)))
 #define funcextend(fn) \
@@ -482,8 +486,6 @@ typedef struct LJEproto
   if (isluafunc(fn) && funcspoof(fn)) { \
       fn = funcspoof(fn); \
   }
-#define protoextend(pt) \
-  (LJEproto*)((char*)(pt) + (pt->sizept - sizeof(LJEproto)))
 
 #define sizeCfunc(n)	(sizeof(GCfuncC)-sizeof(TValue)+sizeof(TValue)*(n))
 #define sizeLfunc(n)	((sizeof(GCfuncL)-sizeof(GCRef)+sizeof(GCRef)*(n)))

--- a/src/lj_parse.c
+++ b/src/lj_parse.c
@@ -1589,8 +1589,6 @@ GCproto *fs_finish(LexState *ls, BCLine line)
   /* LJE: Determine if we're currently compiling LJE */
   if (LJEG()->flag_lje_protos && LJEG()->main_state == ls->L)
   {
-    printf("[LJE]: Parsed proto marked as from LJE!\n");
-    printf("[LJE]: Chunkname: %s\n", strdata(ls->chunkname));
     lje_pt->is_from_lje = 1;
   }
 

--- a/src/lje_signatures.h
+++ b/src/lje_signatures.h
@@ -41,3 +41,6 @@ SIGDEF(lj_cf_math_random, "48 89 5c 24 18 56 48 83 ec 40 48 8b 41 20 48 8b d9 48
 SIGDEF(lj_cf_math_randomseed, "40 53 48 83 ec 20 48 8b 41 20 48 8b 50 f0 48 b8 ff ff ff ff ff 7f 00 00")
 // Allows LJE code to get JITed but still use the alternate random state.
 SIGDEF(recff_math_random, "48 89 5c 24 10 48 89 6c 24 18 48 89 7c 24 20 41 56 48 83 ec 20 48 8b 81 90 00 00 00 41 b8 0c 00 00 00 48 8b f9 48 8b 58 30")
+
+// Allows LJE to block errors
+SIGDEF(lj_err_run, "48 89 5c 24 08 57 48 83 ec 20 4c 8b 49 38 48 8b f9 4c 8b 41 20")


### PR DESCRIPTION
# Changes

- Adds fine-grained error blocking to LJE, meaning any unhandled errors from LJE never make it to GMod.
- Adds foreign pcall protection, ensuring no foreign pcall can ever handle an error from LJE
- Makes all LJE errors now print to console