### PR TITLE
Optimised get_global and engine hooks

### DIFF
--- a/doc/scripting.md
+++ b/doc/scripting.md
@@ -132,10 +132,12 @@ The `lje` table contains all LJE-specific functionality for scripts.
 
 - `lje.include(path: string, execute: boolean = true) -> any`: Includes and optionally executes a Lua file from the script's folder. The path is relative to the script's root folder. If `execute` is false, the file is only loaded and not executed.
 - `lje.con_print(message: string)`: Prints a message to the LJE console with LJE formatting.
-- (lua) `lje.con_printf(format: string, ...)`: Prints a formatted message to the LJE console with LJE formatting. You can wrap text in color tags like `$red{this is red}`.
-- (lua) `lje.detour(original: function, detour: function) -> function`: Detours a function. The detour function should call the original function as needed. Returns the detoured function.
-- (lua) `lje.require(path: string) -> any`: Requires a Lua module from the script's folder. The difference between this and `lje.include` is that `lje.require` caches the module, so subsequent calls to `lje.require` with the same path will return the cached module instead of reloading it.
-- (lua) `cloned_mts`: A table containing copies of known good metatables for various object types.
+- <font color="#2242e3">(GLua)</font> `lje.con_printf(format: string, ...)`: Prints a formatted message to the LJE console with LJE formatting. You can wrap text in color tags like `$red{this is red}`.
+- <font color="#2242e3">(GLua)</font> `lje.detour(original: function, detour: function) -> function`: Detours a function. The detour function should call the original function as needed. Returns the detoured function.
+- <font color="#2242e3">(GLua)</font> `lje.require(path: string) -> any`: Requires a Lua module from the script's folder. The difference between this and `lje.include` is that `lje.require` caches the module, so subsequent calls to `lje.require` with the same path will return the cached module instead of reloading it.
+- <font color="#2242e3">(GLua)</font> `lje.get_global(...: vararg<string>)`: Traverses _G using the given path in the vararg, for example `lje.get_global("hook", "Call")` returns hook.Call
+- <font color="#2242e3">(GLua)</font> `lje.get_global_static(paths: array<string>, count: integer)`: Has the same behaviour as lje.get_global, but instead of using a vararg, you need to pass the array of paths, as well as the number of elements to be used within that array
+- <font color="#2242e3">(GLua)</font> `cloned_mts`: A table containing copies of known good metatables for various object types.
 
 ## `func` API
 
@@ -163,8 +165,8 @@ These functions are protected from debug hooks themselves, so you can safely cal
 - `lje.env.get() -> table`: Gets the current scripting environment table. This is equal to `_L`.
 - `lje.env.disable_metatables()`: Disables metatable resolution globally. This is useful for code that interacts with tables/userdata that may have custom metatables.
 - `lje.env.enable_metatables()`: Enables metatable resolution globally. This should be called after `lje.env.disable_metatables()` to restore normal behavior.
-- `lje.env.save_random_state()`: Saves the current PRNG state.
-- `lje.env.restore_random_state()`: Restores the previously saved PRNG state.
+- <font color="#e32242">(Deprecated)</font> `lje.env.save_random_state()`: Saves the current PRNG state. This function no longer does anything.
+- <font color="#e32242">(Deprecated)</font> `lje.env.restore_random_state()`: Restores the previously saved PRNG state. This function no longer does anything.
 - `lje.env.current_script() -> string`: Returns the name of the currently executing script.
 - `lje.env.is_lua_involved(offset: integer = 0) -> boolean`: Checks if Lua code is involved in the current call stack. The optional `offset` parameter allows you to skip a number of frames from the top of the stack.
 
@@ -185,6 +187,9 @@ These functions are protected from debug hooks themselves, so you can safely cal
 ## `vm` API
 
 - `lje.vm.patch_bytecodes()`: Patches relevant bytecode instructions in the current Lua VM. This is used internally, do not call it manually.
+- <font color="#2242e3">(GLua)</font> `add_engine_call_hook(callback: function)`: Adds the given callback to an array of callbacks which are called whenever set_engine_call_hook fires
+- <font color="#2242e3">(GLua)</font> `remove_engine_call_hook(callback: function)`: Removes the given callback from the engine hook callback array
+- <font color="#2242e3">(GLua)</font> <font color="#7eb547">(Internal)</font> `set_engine_call_hook(callback: function)`: Sets the function to be called whenever the engine tries to call a lua function - Use add_engine_call_hook instead of this as incorrect usage of this function will break other scripts using it
 
 ## `data` API
 

--- a/src/lua/lje_preinit.lua
+++ b/src/lua/lje_preinit.lua
@@ -293,9 +293,9 @@ safeEnv.lje.vm.remove_engine_call_hook = function(fn)
 end
 
 setfenv(safeEnv.lje.vm.add_engine_call_hook, safeEnv)
+setfenv(safeEnv.lje.vm.remove_engine_call_hook, safeEnv)
 setfenv(engineCallHookDispatcher, safeEnv)
 setfenv(engineCallHookNop, safeEnv) -- Not really necessary but it's here anyway
-
 
 lje.vm.set_engine_call_hook(engineCallHookNop)
 lje.con_print("Engine call hook set!")

--- a/src/lua/lje_preinit.lua
+++ b/src/lua/lje_preinit.lua
@@ -27,6 +27,8 @@ end
 cloneTable(_G, safeEnv)
 safeEnv._G = _G -- expose original _G
 
+----------[ Metatables ]----------
+
 lje.con_print("Done! Setting up safe metatables...")
 local function cloneBaseMt(mt)
     local newMt = {}
@@ -110,6 +112,8 @@ end
 setfenv(safeEnv.lje.use_safe_basemts, safeEnv)
 setfenv(safeEnv.lje.restore_basemts, safeEnv)
 
+----------[ Detour ]----------
+
 safeEnv.lje.detour = function(origFn, detourFn)
     lje.func.mark_special(detourFn)
     lje.func.spoof(detourFn, origFn)
@@ -117,6 +121,8 @@ safeEnv.lje.detour = function(origFn, detourFn)
 end
 
 setfenv(safeEnv.lje.detour, safeEnv)
+
+----------[ Require ]----------
 
 local includeCache = {}
 safeEnv.lje.require = function(path)
@@ -138,6 +144,8 @@ safeEnv.lje.require = function(path)
 end
 
 setfenv(safeEnv.lje.require, safeEnv)
+
+----------[ Formatted Printing ]----------
 
 -- Little printf console helper with color parsing
 -- Usage: lje.con_printf("$red{Error}: Something happened!")
@@ -167,55 +175,132 @@ end
 
 setfenv(safeEnv.lje.con_printf, safeEnv)
 
-safeEnv.lje.get_global = function(...)
+----------[ Global Getters ]----------
+
+local type = type
+local rawget = rawget
+local istable = istable
+lje.get_global = function(...)
     -- Basically just a wrapper over rawget to traverse global tables safely
+    -- For a faster version, see lje.get_global_static which does no dynamic allocations and doesn't rely on a vararg
     local paths = {...}
+    local count = #paths
     local current = _G
 
-    for _, key in ipairs(paths) do
-        if type(current) ~= "table" then
+    local i = 1
+    ::iterate_globals::
+    current = rawget(current, paths[i])
+    if (current) then
+        if (i == count) then
+            return current
+        elseif (istable(current)) then
+            i = i + 1
+            goto iterate_globals
+        else
             return nil
         end
-
-        current = rawget(current, key)
-        if current == nil then
-            return nil
-        end
+    else
+        return nil
     end
+end
 
-    return current
+lje.get_global_static = function(paths, count)
+    -- Same behaviour as lje.get_global, but instead of using a vararg,
+    -- you give the function the path as a list (avoid dynamic creation of this as that defeats the purpose of the function),
+    -- along with the number of elements in the list to be traversed
+    local current = _G
+
+    local i = 1
+    ::iterate_globals::
+    current = rawget(current, paths[i])
+    if (current) then
+        if (i == count) then
+            return current
+        elseif (istable(current)) then
+            i = i + 1
+            goto iterate_globals
+        else
+            return nil
+        end
+    else
+        return nil
+    end
 end
 
 setfenv(safeEnv.lje.get_global, safeEnv)
+setfenv(safeEnv.lje.get_global_static, safeEnv)
+
+----------[ Engine Hooks ]----------
 
 local engineCallHooks = {}
+local engineCallHookCount = 0
+
+local function engineCallHookDispatcher(func, nargs, nresults, ...)
+    if (func) then
+        -- No need to check the engineCallHookCount as this function is only set as the hook once a callback is added with add_engine_call_hook
+        local i = 1
+        ::dispatch_engine_hooks::
+        local fallthrough, a, b, c, d, e, f = engineCallHooks[i](func, nargs, nresults, ...) --> Engine hooks don't return more than six values
+        if (not fallthrough) then
+            -- This hook wants to take it, let them handle the call
+            return a, b, c, d, e, f
+        end
+
+        if (i == engineCallHookCount) then
+            -- Otherwise, there's basically no hook that wants to dispatch this call, so we'll do it.
+            return func(...)
+        else
+            i = i + 1
+            goto dispatch_engine_hooks
+        end
+    end
+end
+
+local function engineCallHookNop(func, nargs, nresults, ...)
+    return func(...) -- Used when there are no callbacks added with add_engine_call_hook to avoid unnecessary computation
+end
+
 safeEnv.lje.vm.add_engine_call_hook = function(fn)
-  lje.func.mark_special(fn)
-  table.insert(engineCallHooks, fn)
+    lje.func.mark_special(fn)
+    table.insert(engineCallHooks, fn)
+
+    if (engineCallHookCount == 0) then
+        lje.vm.set_engine_call_hook(engineCallHookDispatcher)
+    end
+
+    engineCallHookCount = engineCallHookCount + 1
+end
+
+safeEnv.lje.vm.remove_engine_call_hook = function(fn)
+    if (engineCallHookCount == 0) then
+        return
+    end
+
+    local i = 1
+    ::remove_engine_hook::
+    if (engineCallHooks[i] == fn) then
+        local newcount = engineCallHookCount - 1
+        engineCallHookCount = newcount
+        if (newcount == 0) then
+            lje.vm.set_engine_call_hook(engineCallHookNop)
+        end
+
+        table.remove(engineCallHooks, i)
+    elseif (i ~= engineCallHookCount) then
+        i = i + 1
+        goto remove_engine_hook
+    end
 end
 
 setfenv(safeEnv.lje.vm.add_engine_call_hook, safeEnv)
-
-local function engineCallHookDispatcher(func, nargs, nresults, ...)
-  if func == nil then
-    return
-  end
-
-  for _, hookFn in ipairs(engineCallHooks) do
-    local results = {hookFn(func, nargs, nresults, ...)}
-    if not results[1] then
-        -- This hook wants to take it, let them handle the call
-        return unpack(results, 2)
-    end
-  end
-
-  -- Otherwise, there's basically no hook that wants to dispatch this call, so we'll do it.
-  return func(...)
-end
-
 setfenv(engineCallHookDispatcher, safeEnv)
-lje.vm.set_engine_call_hook(engineCallHookDispatcher)
+setfenv(engineCallHookNop, safeEnv) -- Not really necessary but it's here anyway
+
+
+lje.vm.set_engine_call_hook(engineCallHookNop)
 lje.con_print("Engine call hook set!")
+
+----------[ Environment Setup ]----------
 
 -- Add a circular reference to the safe environment in the safeEnv
 safeEnv._L = safeEnv

--- a/src/lua/lje_preinit.lua
+++ b/src/lua/lje_preinit.lua
@@ -180,6 +180,7 @@ setfenv(safeEnv.lje.con_printf, safeEnv)
 local type = type
 local rawget = rawget
 local istable = istable
+local _G = _G
 lje.get_global = function(...)
     -- Basically just a wrapper over rawget to traverse global tables safely
     -- For a faster version, see lje.get_global_static which does no dynamic allocations and doesn't rely on a vararg


### PR DESCRIPTION
**Additions:**
```lua
lje.vm.remove_engine_call_hook(func : function)
lje.get_global_static(paths : array<string>, count : integer)
```

**Changes**
lje.get_global and engineCallHookDispatcher are a lot faster now

**Notes**
I was having issues compiling the repository because some files are missing so you should test this before accepting as I wasn't able to do that